### PR TITLE
corrected typing mistake

### DIFF
--- a/libs/artnet/src/network.c
+++ b/libs/artnet/src/network.c
@@ -45,12 +45,12 @@ typedef int socklen_t;
 //custermized by horristic
 #ifndef WIN32
 //modified by James Kong
-#ifdef TARGET_LINUX_ARM
+#ifndef __unix
   #include <ifaddrs.h>
   #include <net/if_types.h>
   #include <net/if_dl.h>
 #else
-//support RaspberryPi
+// support RaspberryPi
   #include <ifaddrs.h>
 #endif
 #endif


### PR DESCRIPTION
use __unix marco define instead
