### PR TITLE
fix about memory allocation and thread safe.

### DIFF
--- a/src/artnet/ofxArtnetMessage.cpp
+++ b/src/artnet/ofxArtnetMessage.cpp
@@ -1,10 +1,10 @@
 #include "ofxArtnetMessage.h"
 
-ofxArtnetMessage::ofxArtnetMessage():_data(nullptr)
+ofxArtnetMessage::ofxArtnetMessage() : _data()
 {
 }
 
-ofxArtnetMessage::ofxArtnetMessage(const ofPixels& pix) : _data(nullptr), _size(0), _universe(0), _subnet(0), _net(0), _portAddress(0)
+ofxArtnetMessage::ofxArtnetMessage(const ofPixels& pix) : _data(), _universe(0), _subnet(0), _net(0), _portAddress(0)
 {
 	setData(pix);
 }
@@ -15,29 +15,25 @@ ofxArtnetMessage::~ofxArtnetMessage()
 	clear();
 }
 
-ofxArtnetMessage::ofxArtnetMessage(const ofxArtnetMessage& origin) : _data(nullptr), _size(0), _universe(0), _subnet(0), _net(0), _portAddress(0)
-{
-	if (origin._data != nullptr)
-	{
-		_data = new unsigned char[origin._size];
-		memcpy(_data, origin._data, origin._size);
-		this->_size = origin._size;
-	}
-	this->_universe = origin._universe;
-	this->_subnet = origin._subnet;
-	this->_net = origin._net;
-	this->_portAddress = origin._portAddress;
-}
+ofxArtnetMessage::ofxArtnetMessage(const ofxArtnetMessage& origin)
+: _data(origin._data)
+, _universe(origin._universe)
+, _subnet(origin._subnet)
+, _net(origin._net)
+, _portAddress(origin._portAddress)
+{}
+
+ofxArtnetMessage::ofxArtnetMessage(ofxArtnetMessage&& origin)
+: _data(std::move(origin._data))
+, _universe(origin._universe)
+, _subnet(origin._subnet)
+, _net(origin._net)
+, _portAddress(origin._portAddress)
+{}
 
 ofxArtnetMessage& ofxArtnetMessage::operator = (const ofxArtnetMessage& origin)
 {
-	this->_size = 0;
-	if (origin._data != nullptr)
-	{
-		_data = new unsigned char[origin._size];
-		memcpy(_data, origin._data, origin._size);
-		this->_size = origin._size;
-	}
+    _data = origin._data;
 	this->_universe = origin._universe;
 	this->_subnet = origin._subnet;
 	this->_net = origin._net;
@@ -46,26 +42,24 @@ ofxArtnetMessage& ofxArtnetMessage::operator = (const ofxArtnetMessage& origin)
 }
 
 
-void ofxArtnetMessage::allocate(unsigned int size)
+void ofxArtnetMessage::allocate(size_t size)
 {
-	_data = new unsigned char[size];
-	_size = size;
+    _data.resize(size);
 }
-
-
 
 void ofxArtnetMessage::readTo(unsigned char* data)
 {
-	memcpy(data, _data, _size);
+	memcpy(data, _data.data(), _data.size());
+}
+
+void ofxArtnetMessage::readTo(std::vector<uint8_t> &data)
+{
+    data = _data;
 }
 
 void ofxArtnetMessage::clear()
 {
-	if (_data != nullptr)
-	{
-		delete[] _data;
-		_data = nullptr;
-	}
+    _data.clear();
 }
 
 void ofxArtnetMessage::setData(const ofPixels& pix)
@@ -74,25 +68,23 @@ void ofxArtnetMessage::setData(const ofPixels& pix)
 	setData(pix.getData(), datasize);
 }
 
-void ofxArtnetMessage::setData(ofIndexType index, unsigned char& data)
+void ofxArtnetMessage::setData(std::vector<uint8_t> &data) {
+    _data = data;
+}
+
+void ofxArtnetMessage::setData(ofIndexType index, unsigned char data)
 {
-	if (_data == nullptr || _size < index + 1)
-	{
+	if (getSize() <= index) {
 		ofLogWarning() << "data size is not big enouth";
 		return;
 	}
 	_data[index] = data;
 }
 
-void ofxArtnetMessage::setData(const unsigned char* data, const int size)
+void ofxArtnetMessage::setData(const unsigned char* data, size_t size)
 {
-	std::unique_lock<std::mutex> lock(mutex);
-	if (_data == nullptr)
-	{
-		_data = new unsigned char[size];
-	}
-	memcpy(_data, data, size);
-	_size = size;
+    _data.resize(size);
+	memcpy(_data.data(), data, size);
 	_seqNo++;
 	_seqNo %= 256;
 }

--- a/src/artnet/ofxArtnetMessage.h
+++ b/src/artnet/ofxArtnetMessage.h
@@ -10,14 +10,18 @@ public:
 	ofxArtnetMessage(const ofPixels& pix);
 	~ofxArtnetMessage();
 	ofxArtnetMessage(const ofxArtnetMessage& origin);
+    ofxArtnetMessage(ofxArtnetMessage&& origin);
 
-	void allocate(unsigned int size);
+	void allocate(size_t size);
 	void clear();
-	void setData(const unsigned char* data, int size);
-	void setData(ofIndexType index, unsigned char& data);
+    
+	void setData(const unsigned char* data, size_t size);
+	void setData(ofIndexType index, unsigned char data);
 	void setData(const ofPixels& pix);
+    void setData(std::vector<uint8_t> &data);
 
 	void readTo(unsigned char* data);
+    void readTo(std::vector<uint8_t> &data);
 
 	inline void setUniverse15(unsigned int universe) { _portAddress = _universe = universe; }
 	inline void setUniverse(unsigned int net, unsigned int subnet, unsigned int universe)
@@ -30,15 +34,14 @@ public:
 	inline unsigned int getUniverse() const { return _universe; }
 	inline unsigned int getSubnet() const { return _subnet; }
 	inline unsigned int getNet() const { return _net; }
-	inline unsigned int getSize() const { return _size; }
+	inline unsigned int getSize() const { return _data.size(); }
 	ofxArtnetMessage& operator = (const ofxArtnetMessage& obj);
 private:
 	inline unsigned int getPortAddess() const { return _portAddress; }
 	inline unsigned char getSequence() const { return _seqNo; }
-	unsigned int _universe, _subnet, _net, _size;
-	unsigned char* _data;
+	unsigned int _universe, _subnet, _net;
+    std::vector<uint8_t> _data;
 	unsigned int _portAddress;
 	unsigned char _seqNo;
-    std::mutex mutex;
 };
 

--- a/src/artnet/ofxArtnetProtocol.h
+++ b/src/artnet/ofxArtnetProtocol.h
@@ -14,6 +14,6 @@ class ofxArtnetProtocol
 	protected:
 		ofxUDPManager udp;
 		const std::string HEAD = "Art-Net";
-		const int HEADER_LENGTH = 18;
-		const short OP_OUTPUT = 0x5000;
+		static constexpr int HEADER_LENGTH = 18;
+		static constexpr short OP_OUTPUT = 0x5000;
 };

--- a/src/artnet/ofxArtnetReceiver.cpp
+++ b/src/artnet/ofxArtnetReceiver.cpp
@@ -21,43 +21,55 @@ void ofxArtnetReceiver::setup(const uint16_t port)
 	settings.blocking = false;
 	udp.Setup(settings);
 	startThread();
-
 }
 
 bool ofxArtnetReceiver::hasMessage() const
 {
-	return isDataNew;
+	return !receivedDataChannel.empty();
 }
 
 void ofxArtnetReceiver::getData(ofxArtnetMessage& m)
 {
-	std::unique_lock<std::mutex> lock(mutex);
-	m = receivedData;
+    if(!hasMessage()) {
+        ofLogWarning("ofxArtnet") << "no new data. copy previous data.";
+    }
+    while(hasMessage()) {
+        receivedDataChannel.receive(receivedData);
+    }
+    m = receivedData;
 }
 
+void ofxArtnetReceiver::getNextData(ofxArtnetMessage& m)
+{
+    if(hasMessage()) {
+        receivedDataChannel.receive(receivedData);
+    } else {
+        ofLogWarning("ofxArtnet") << "no new data. copy previous data.";
+    }
+    m = receivedData;
+}
 
 void ofxArtnetReceiver::threadedFunction()
 {
+    unsigned char data[HEADER_LENGTH + 512];
 	while (isThreadRunning())
 	{
-		char *data = new char[HEADER_LENGTH + 512];
-		udp.Receive(data, HEADER_LENGTH + 512);
-		std::string protcol_id(data, 7);
+        memset(data, 0, HEADER_LENGTH + 512);
+		udp.Receive((char *)data, HEADER_LENGTH + 512);
+		std::string protcol_id((char *)data, 7);
 		if (protcol_id == "Art-Net")
 		{
 			if (data[8] == (OP_OUTPUT & 0xff) && data[9] == ((OP_OUTPUT >> 8) & 0xff))
 			{
+                ofxArtnetMessage receivedData;
 				int versionHi = data[HEADER_LENGTH-8];
 				int versionLo = data[HEADER_LENGTH-7];
 				int seq = data[HEADER_LENGTH-6];
 				int physical = data[HEADER_LENGTH-5];
 				receivedData._portAddress = data[HEADER_LENGTH-4] + (data[HEADER_LENGTH-3] << 8);
 				int dataSize = (data[HEADER_LENGTH - 2] << 8) + (data[HEADER_LENGTH - 1] & 0xff);
-				receivedData.allocate(dataSize);
-				isDataNew = true;
-				memcpy(receivedData._data, data + HEADER_LENGTH, dataSize);
+                receivedData.setData(data + HEADER_LENGTH, dataSize);
 			}
 		}
-		delete[] data;
 	}
 }

--- a/src/artnet/ofxArtnetReceiver.h
+++ b/src/artnet/ofxArtnetReceiver.h
@@ -11,10 +11,12 @@ public:
 
 	bool hasMessage() const;
 	void getData(ofxArtnetMessage& m);
+    void getNextData(ofxArtnetMessage& m);
 protected:
 	void threadedFunction();
 	bool isDataNew = false;
 	int size;
-	ofxArtnetMessage receivedData;
+    ofThreadChannel<ofxArtnetMessage> receivedDataChannel;
+    ofxArtnetMessage receivedData;
 };
 

--- a/src/artnet/ofxArtnetSender.cpp
+++ b/src/artnet/ofxArtnetSender.cpp
@@ -74,7 +74,7 @@ void ofxArtnetSender::createBuffer(const ofxArtnetMessage& message, std::vector<
 	data[HEADER_LENGTH - 2] = (datasize >> 8);
 	data[HEADER_LENGTH - 1] = (datasize & 0xff);
 	ofLog() << datasize;
-	memcpy(&data[HEADER_LENGTH], message._data, message.getSize());
+	memcpy(&data[HEADER_LENGTH], message._data.data(), message.getSize());
 }
 
 void ofxArtnetSender::sendData(const ofxArtnetMessage& message)

--- a/src/artnet/ofxArtnetSender.h
+++ b/src/artnet/ofxArtnetSender.h
@@ -35,7 +35,7 @@ protected:
 	float framerate = 40;
 	float interval = 25;
 
-	vector<ofxArtnetMessage> _messages;
+    std::vector<ofxArtnetMessage> _messages;
 	void createBuffer(const ofxArtnetMessage& message, std::vector<unsigned char>& data);
 	void sendData(const ofxArtnetMessage& message);
 };


### PR DESCRIPTION
* replace raw pointer with `std::vector`
* use `ofThreadChannel` for receiving data.
* add `getNextData(ofxArtnetMessage &)` to get received messages.
    * `getData(ofxArtnetMessage &)` clears queued messages and get only last received.